### PR TITLE
feat: add anti-hoarding economy mechanisms

### DIFF
--- a/src/economy/antihoarding.ts
+++ b/src/economy/antihoarding.ts
@@ -1,0 +1,264 @@
+export interface EconomyConfig {
+  velocityBonusRate: number;
+  stagnationThresholdDays: number;
+  decayRatePerDay: number;
+  softCapAmount: number;
+  hardCapAmount: number;
+  velocityWindowDays: number;
+  maxVelocityTransactions: number;
+}
+
+export interface AgentEconomyState {
+  agentId: string;
+  balance: number;
+  transactionTimestamps: Date[];
+  earnedAmount: number;
+  contributedAmount: number;
+  completedTasks: number;
+}
+
+export interface VelocityBonus {
+  agentId: string;
+  transactionCount: number;
+  velocityScore: number;
+  multiplier: number;
+  bonusRate: number;
+}
+
+export interface DecayResult {
+  agentId: string;
+  daysSinceActivity: number;
+  decayAmount: number;
+  remainingBalance: number;
+  commonsPoolAmount: number;
+}
+
+export interface ContributionCapResult {
+  agentId: string;
+  status: 'OK' | 'SOFT_CAP' | 'HARD_CAP';
+  balance: number;
+  warning?: string;
+  reducedEarningMultiplier: number;
+  forcedRedistributionAmount: number;
+}
+
+export interface RedistributionRecipient {
+  agentId: string;
+  needScore: number;
+}
+
+export interface RedistributionAllocation {
+  agentId: string;
+  amount: number;
+}
+
+export interface RedistributionEvent {
+  id: string;
+  amount: number;
+  allocations: RedistributionAllocation[];
+  createdAt: string;
+  auditLog: string[];
+}
+
+export interface CirculationMetrics {
+  totalBalance: number;
+  activeAgentCount: number;
+  idleAgentCount: number;
+  velocityAverage: number;
+  hoardingRisk: number;
+  commonsPoolProjected: number;
+}
+
+export const DEFAULT_ECONOMY_CONFIG: EconomyConfig = {
+  velocityBonusRate: 0.5,
+  stagnationThresholdDays: 30,
+  decayRatePerDay: 0.001,
+  softCapAmount: 100_000,
+  hardCapAmount: 500_000,
+  velocityWindowDays: 30,
+  maxVelocityTransactions: 20,
+};
+
+export function calculateVelocityBonus(
+  agent: AgentEconomyState,
+  config: EconomyConfig = DEFAULT_ECONOMY_CONFIG,
+  now = new Date()
+): VelocityBonus {
+  const windowStart = addDays(now, -config.velocityWindowDays);
+  const transactionCount = agent.transactionTimestamps.filter(
+    (timestamp) => timestamp >= windowStart && timestamp <= now
+  ).length;
+  const velocityScore = clamp(transactionCount / config.maxVelocityTransactions, 0, 1);
+  const bonusRate = config.velocityBonusRate * velocityScore;
+
+  return {
+    agentId: agent.agentId,
+    transactionCount,
+    velocityScore,
+    multiplier: 1 + bonusRate,
+    bonusRate,
+  };
+}
+
+export function applyStagnationDecay(
+  agents: AgentEconomyState[],
+  config: EconomyConfig = DEFAULT_ECONOMY_CONFIG,
+  now = new Date()
+): DecayResult[] {
+  return agents
+    .map((agent) => {
+      const daysSinceActivity = getDaysSinceLastActivity(agent, now);
+      if (daysSinceActivity <= config.stagnationThresholdDays) {
+        return {
+          agentId: agent.agentId,
+          daysSinceActivity,
+          decayAmount: 0,
+          remainingBalance: agent.balance,
+          commonsPoolAmount: 0,
+        };
+      }
+
+      const idleDays = daysSinceActivity - config.stagnationThresholdDays;
+      const decayAmount = Math.min(agent.balance, agent.balance * config.decayRatePerDay * idleDays);
+
+      return {
+        agentId: agent.agentId,
+        daysSinceActivity,
+        decayAmount: roundSats(decayAmount),
+        remainingBalance: roundSats(agent.balance - decayAmount),
+        commonsPoolAmount: roundSats(decayAmount),
+      };
+    })
+    .filter((result) => result.decayAmount > 0);
+}
+
+export function checkContributionCap(
+  agent: AgentEconomyState,
+  config: EconomyConfig = DEFAULT_ECONOMY_CONFIG
+): ContributionCapResult {
+  if (agent.balance >= config.hardCapAmount) {
+    return {
+      agentId: agent.agentId,
+      status: 'HARD_CAP',
+      balance: agent.balance,
+      warning: 'Hard cap exceeded; balance above the hard cap is redistributed.',
+      reducedEarningMultiplier: 0,
+      forcedRedistributionAmount: roundSats(agent.balance - config.hardCapAmount),
+    };
+  }
+
+  if (agent.balance >= config.softCapAmount) {
+    const capRange = config.hardCapAmount - config.softCapAmount;
+    const progress = capRange > 0 ? (agent.balance - config.softCapAmount) / capRange : 1;
+
+    return {
+      agentId: agent.agentId,
+      status: 'SOFT_CAP',
+      balance: agent.balance,
+      warning: 'Soft cap reached; earnings are reduced until value circulates.',
+      reducedEarningMultiplier: clamp(1 - progress * 0.5, 0.5, 1),
+      forcedRedistributionAmount: 0,
+    };
+  }
+
+  return {
+    agentId: agent.agentId,
+    status: 'OK',
+    balance: agent.balance,
+    reducedEarningMultiplier: 1,
+    forcedRedistributionAmount: 0,
+  };
+}
+
+export function executeRedistribution(
+  amount: number,
+  recipients: RedistributionRecipient[],
+  eventId = `redistribution-${Date.now()}`
+): RedistributionEvent {
+  if (amount <= 0) throw new Error('Redistribution amount must be positive.');
+  if (recipients.length === 0) throw new Error('At least one recipient is required.');
+
+  const totalNeed = recipients.reduce((sum, recipient) => sum + Math.max(recipient.needScore, 0), 0);
+  if (totalNeed <= 0) throw new Error('At least one recipient must have a positive need score.');
+
+  let allocated = 0;
+  const allocations = recipients.map((recipient, index) => {
+    const isLast = index === recipients.length - 1;
+    const rawAmount = isLast
+      ? amount - allocated
+      : amount * (Math.max(recipient.needScore, 0) / totalNeed);
+    const recipientAmount = roundSats(rawAmount);
+    allocated += recipientAmount;
+    return {
+      agentId: recipient.agentId,
+      amount: recipientAmount,
+    };
+  });
+
+  return {
+    id: eventId,
+    amount: roundSats(amount),
+    allocations,
+    createdAt: new Date().toISOString(),
+    auditLog: allocations.map(
+      (allocation) => `Redistributed ${allocation.amount} sats to ${allocation.agentId}`
+    ),
+  };
+}
+
+export function getCirculationMetrics(
+  agents: AgentEconomyState[],
+  config: EconomyConfig = DEFAULT_ECONOMY_CONFIG,
+  now = new Date()
+): CirculationMetrics {
+  const totalBalance = agents.reduce((sum, agent) => sum + agent.balance, 0);
+  const activeAgents = agents.filter(
+    (agent) => getDaysSinceLastActivity(agent, now) <= config.stagnationThresholdDays
+  );
+  const idleAgentCount = agents.length - activeAgents.length;
+  const velocityAverage =
+    agents.length === 0
+      ? 0
+      : agents.reduce(
+          (sum, agent) => sum + calculateVelocityBonus(agent, config, now).velocityScore,
+          0
+        ) / agents.length;
+  const balancesAboveSoftCap = agents.filter((agent) => agent.balance >= config.softCapAmount).length;
+  const hoardingRisk = agents.length === 0 ? 0 : balancesAboveSoftCap / agents.length;
+  const commonsPoolProjected = applyStagnationDecay(agents, config, now).reduce(
+    (sum, result) => sum + result.commonsPoolAmount,
+    0
+  );
+
+  return {
+    totalBalance: roundSats(totalBalance),
+    activeAgentCount: activeAgents.length,
+    idleAgentCount,
+    velocityAverage: Number(velocityAverage.toFixed(4)),
+    hoardingRisk: Number(hoardingRisk.toFixed(4)),
+    commonsPoolProjected: roundSats(commonsPoolProjected),
+  };
+}
+
+function getDaysSinceLastActivity(agent: AgentEconomyState, now: Date): number {
+  if (agent.transactionTimestamps.length === 0) return Number.POSITIVE_INFINITY;
+  const lastActivity = agent.transactionTimestamps.reduce((latest, timestamp) =>
+    timestamp > latest ? timestamp : latest
+  );
+  return Math.floor((now.getTime() - lastActivity.getTime()) / 86_400_000);
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function roundSats(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value);
+}

--- a/src/economy/antihoarding.ts
+++ b/src/economy/antihoarding.ts
@@ -173,7 +173,7 @@ export function checkContributionCap(
 export function executeRedistribution(
   amount: number,
   recipients: RedistributionRecipient[],
-  eventId = `redistribution-${Date.now()}`
+  eventId = `redistribution-${randomUUID()}`
 ): RedistributionEvent {
   if (amount <= 0) throw new Error('Redistribution amount must be positive.');
   if (recipients.length === 0) throw new Error('At least one recipient is required.');
@@ -211,28 +211,33 @@ export function getCirculationMetrics(
   config: EconomyConfig = DEFAULT_ECONOMY_CONFIG,
   now = new Date()
 ): CirculationMetrics {
-  const totalBalance = agents.reduce((sum, agent) => sum + agent.balance, 0);
-  const activeAgents = agents.filter(
-    (agent) => getDaysSinceLastActivity(agent, now) <= config.stagnationThresholdDays
-  );
-  const idleAgentCount = agents.length - activeAgents.length;
-  const velocityAverage =
-    agents.length === 0
-      ? 0
-      : agents.reduce(
-          (sum, agent) => sum + calculateVelocityBonus(agent, config, now).velocityScore,
-          0
-        ) / agents.length;
-  const balancesAboveSoftCap = agents.filter((agent) => agent.balance >= config.softCapAmount).length;
+  let totalBalance = 0;
+  let activeAgentCount = 0;
+  let velocityTotal = 0;
+  let balancesAboveSoftCap = 0;
+  let commonsPoolProjected = 0;
+
+  for (const agent of agents) {
+    totalBalance += agent.balance;
+    velocityTotal += calculateVelocityBonus(agent, config, now).velocityScore;
+    if (agent.balance >= config.softCapAmount) balancesAboveSoftCap += 1;
+
+    const daysSinceActivity = getDaysSinceLastActivity(agent, now);
+    if (daysSinceActivity <= config.stagnationThresholdDays) {
+      activeAgentCount += 1;
+    } else {
+      const idleDays = daysSinceActivity - config.stagnationThresholdDays;
+      commonsPoolProjected += roundSats(Math.min(agent.balance, agent.balance * config.decayRatePerDay * idleDays));
+    }
+  }
+
+  const idleAgentCount = agents.length - activeAgentCount;
+  const velocityAverage = agents.length === 0 ? 0 : velocityTotal / agents.length;
   const hoardingRisk = agents.length === 0 ? 0 : balancesAboveSoftCap / agents.length;
-  const commonsPoolProjected = applyStagnationDecay(agents, config, now).reduce(
-    (sum, result) => sum + result.commonsPoolAmount,
-    0
-  );
 
   return {
     totalBalance: roundSats(totalBalance),
-    activeAgentCount: activeAgents.length,
+    activeAgentCount,
     idleAgentCount,
     velocityAverage: Number(velocityAverage.toFixed(4)),
     hoardingRisk: Number(hoardingRisk.toFixed(4)),
@@ -242,9 +247,7 @@ export function getCirculationMetrics(
 
 function getDaysSinceLastActivity(agent: AgentEconomyState, now: Date): number {
   if (agent.transactionTimestamps.length === 0) return Number.POSITIVE_INFINITY;
-  const lastActivity = agent.transactionTimestamps.reduce((latest, timestamp) =>
-    timestamp > latest ? timestamp : latest
-  );
+  const lastActivity = new Date(Math.max(...agent.transactionTimestamps.map((timestamp) => timestamp.getTime())));
   return Math.floor((now.getTime() - lastActivity.getTime()) / 86_400_000);
 }
 
@@ -262,3 +265,4 @@ function roundSats(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.round(value);
 }
+import { randomUUID } from 'node:crypto';

--- a/tests/economy/antihoarding.test.ts
+++ b/tests/economy/antihoarding.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ECONOMY_CONFIG,
+  applyStagnationDecay,
+  calculateVelocityBonus,
+  checkContributionCap,
+  executeRedistribution,
+  getCirculationMetrics,
+  type AgentEconomyState,
+} from '../../src/economy/antihoarding.js';
+
+const now = new Date('2026-05-10T00:00:00Z');
+
+function agent(overrides: Partial<AgentEconomyState>): AgentEconomyState {
+  return {
+    agentId: 'agent-1',
+    balance: 0,
+    transactionTimestamps: [],
+    earnedAmount: 0,
+    contributedAmount: 0,
+    completedTasks: 0,
+    ...overrides,
+  };
+}
+
+describe('anti-hoarding economy mechanisms', () => {
+  it('calculates velocity bonus from recent transaction activity', () => {
+    const active = agent({
+      transactionTimestamps: Array.from({ length: 10 }, (_, index) =>
+        new Date(`2026-05-${String(index + 1).padStart(2, '0')}T00:00:00Z`)
+      ),
+    });
+
+    const bonus = calculateVelocityBonus(active, DEFAULT_ECONOMY_CONFIG, now);
+
+    expect(bonus.transactionCount).toBe(10);
+    expect(bonus.velocityScore).toBe(0.5);
+    expect(bonus.multiplier).toBe(1.25);
+  });
+
+  it('applies stagnation decay only after the configured idle threshold', () => {
+    const results = applyStagnationDecay(
+      [
+        agent({
+          agentId: 'idle',
+          balance: 10_000,
+          transactionTimestamps: [new Date('2026-03-01T00:00:00Z')],
+        }),
+        agent({
+          agentId: 'active',
+          balance: 10_000,
+          transactionTimestamps: [new Date('2026-05-01T00:00:00Z')],
+        }),
+      ],
+      DEFAULT_ECONOMY_CONFIG,
+      now
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].agentId).toBe('idle');
+    expect(results[0].decayAmount).toBeGreaterThan(0);
+    expect(results[0].commonsPoolAmount).toBe(results[0].decayAmount);
+  });
+
+  it('checks soft and hard contribution caps', () => {
+    const soft = checkContributionCap(agent({ balance: 200_000 }));
+    const hard = checkContributionCap(agent({ balance: 650_000 }));
+
+    expect(soft.status).toBe('SOFT_CAP');
+    expect(soft.reducedEarningMultiplier).toBeLessThan(1);
+    expect(hard.status).toBe('HARD_CAP');
+    expect(hard.reducedEarningMultiplier).toBe(0);
+    expect(hard.forcedRedistributionAmount).toBe(150_000);
+  });
+
+  it('executes weighted redistribution with an audit log', () => {
+    const event = executeRedistribution(
+      1_000,
+      [
+        { agentId: 'low-need', needScore: 1 },
+        { agentId: 'high-need', needScore: 3 },
+      ],
+      'event-1'
+    );
+
+    expect(event.id).toBe('event-1');
+    expect(event.allocations).toEqual([
+      { agentId: 'low-need', amount: 250 },
+      { agentId: 'high-need', amount: 750 },
+    ]);
+    expect(event.auditLog).toHaveLength(2);
+  });
+
+  it('reports circulation metrics for active, idle, and capped agents', () => {
+    const metrics = getCirculationMetrics(
+      [
+        agent({
+          agentId: 'active',
+          balance: 50_000,
+          transactionTimestamps: [new Date('2026-05-08T00:00:00Z')],
+        }),
+        agent({
+          agentId: 'idle',
+          balance: 20_000,
+          transactionTimestamps: [new Date('2026-03-01T00:00:00Z')],
+        }),
+        agent({
+          agentId: 'capped',
+          balance: 600_000,
+          transactionTimestamps: [new Date('2026-05-02T00:00:00Z')],
+        }),
+      ],
+      DEFAULT_ECONOMY_CONFIG,
+      now
+    );
+
+    expect(metrics.totalBalance).toBe(670_000);
+    expect(metrics.activeAgentCount).toBe(2);
+    expect(metrics.idleAgentCount).toBe(1);
+    expect(metrics.hoardingRisk).toBeCloseTo(1 / 3, 4);
+    expect(metrics.commonsPoolProjected).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/economy/antihoarding.ts` with velocity bonus calculation, stagnation decay, contribution cap checks, weighted redistribution events, and circulation metrics
- add focused Vitest coverage for all requested core mechanisms

Closes #10.

## Verification
- `npx vitest run tests/economy/antihoarding.test.ts` -> 5 passed

Note: repo-wide `npm run build` is currently blocked by existing project configuration/dependency/type issues unrelated to this module, documented in PR #17.

Payout details: I can provide a Lightning invoice/address if this is accepted for the 2,000 sats bounty.