### PR TITLE
feat: add bounty matcher

### DIFF
--- a/src/bounty/matcher.ts
+++ b/src/bounty/matcher.ts
@@ -1,0 +1,230 @@
+export type AgentLevel = 'L0_CANDIDATE' | 'L1_WORKER' | 'L2_EMERGENT' | 'L3_SOVEREIGN' | 'L4_MANAGER';
+
+export interface MatchAgent {
+  id: string;
+  level: AgentLevel;
+  capabilities: string[];
+  interests?: string[];
+  preferredDomains?: string[];
+  activeTaskCount: number;
+  maxConcurrentTasks: number;
+  reputationScore: number;
+  completedTasksByDomain?: Record<string, number>;
+  podIds?: string[];
+  optInAutoAssign?: boolean;
+}
+
+export interface MatchTask {
+  id: string;
+  domain: string;
+  requiredLevel: AgentLevel;
+  requiredCapabilities: string[];
+  tags?: string[];
+  podId?: string;
+  status: 'AVAILABLE' | 'CLAIMED' | 'SUBMITTED' | 'COMPLETED' | 'DISPUTED';
+}
+
+export interface MatchDataSource {
+  agents: MatchAgent[];
+  tasks: MatchTask[];
+}
+
+export interface MatchScoreBreakdown {
+  levelMatch: number;
+  capabilityOverlap: number;
+  domainExperience: number;
+  availabilityScore: number;
+  podBonus: number;
+  preferenceScore: number;
+  reputationMultiplier: number;
+}
+
+export interface MatchResult {
+  agentId: string;
+  taskId: string;
+  score: number;
+  breakdown: MatchScoreBreakdown;
+  reasons: string[];
+}
+
+export interface SkillDevelopmentSuggestion {
+  capability: string;
+  matchingTaskCount: number;
+  reason: string;
+}
+
+const LEVEL_RANK: Record<AgentLevel, number> = {
+  L0_CANDIDATE: 0,
+  L1_WORKER: 1,
+  L2_EMERGENT: 2,
+  L3_SOVEREIGN: 3,
+  L4_MANAGER: 4,
+};
+
+export function findMatchingAgents(taskId: string, data: MatchDataSource): MatchResult[] {
+  const task = getTask(taskId, data);
+  if (task.status !== 'AVAILABLE') return [];
+
+  return data.agents
+    .map((agent) => calculateMatchScore(agent.id, task.id, data))
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score);
+}
+
+export function findMatchingTasks(agentId: string, data: MatchDataSource): MatchResult[] {
+  getAgent(agentId, data);
+
+  return data.tasks
+    .filter((task) => task.status === 'AVAILABLE')
+    .map((task) => calculateMatchScore(agentId, task.id, data))
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score);
+}
+
+export function calculateMatchScore(
+  agentId: string,
+  taskId: string,
+  data: MatchDataSource
+): MatchResult {
+  const agent = getAgent(agentId, data);
+  const task = getTask(taskId, data);
+  const breakdown = buildBreakdown(agent, task);
+  const baseScore =
+    breakdown.levelMatch * 30 +
+    breakdown.capabilityOverlap * 25 +
+    breakdown.domainExperience * 20 +
+    breakdown.availabilityScore * 15 +
+    breakdown.podBonus * 10 +
+    breakdown.preferenceScore * 5;
+  const score = Math.round(baseScore * breakdown.reputationMultiplier);
+
+  return {
+    agentId,
+    taskId,
+    score,
+    breakdown,
+    reasons: buildReasons(agent, task, breakdown),
+  };
+}
+
+export function autoAssignTask(taskId: string, data: MatchDataSource): MatchResult | null {
+  const eligible = findMatchingAgents(taskId, data).filter((result) => {
+    const agent = getAgent(result.agentId, data);
+    return agent.optInAutoAssign === true && result.breakdown.availabilityScore > 0;
+  });
+
+  return eligible[0] ?? null;
+}
+
+export function suggestSkillDevelopment(
+  agentId: string,
+  data: MatchDataSource,
+  limit = 5
+): SkillDevelopmentSuggestion[] {
+  const agent = getAgent(agentId, data);
+  const ownedCapabilities = new Set(agent.capabilities.map(normalize));
+  const counts = new Map<string, number>();
+
+  for (const task of data.tasks.filter((item) => item.status === 'AVAILABLE')) {
+    for (const capability of task.requiredCapabilities) {
+      const normalized = normalize(capability);
+      if (!ownedCapabilities.has(normalized)) {
+        counts.set(capability, (counts.get(capability) ?? 0) + 1);
+      }
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([capability, matchingTaskCount]) => ({
+      capability,
+      matchingTaskCount,
+      reason: `${matchingTaskCount} available task(s) require ${capability}.`,
+    }));
+}
+
+function buildBreakdown(agent: MatchAgent, task: MatchTask): MatchScoreBreakdown {
+  const levelMatch = LEVEL_RANK[agent.level] >= LEVEL_RANK[task.requiredLevel] ? 1 : 0;
+  const capabilityOverlap = calculateCapabilityOverlap(agent.capabilities, task.requiredCapabilities);
+  const domainExperience = clamp((agent.completedTasksByDomain?.[task.domain] ?? 0) / 10, 0, 1);
+  const availabilityScore =
+    agent.maxConcurrentTasks <= 0
+      ? 0
+      : clamp((agent.maxConcurrentTasks - agent.activeTaskCount) / agent.maxConcurrentTasks, 0, 1);
+  const podBonus = task.podId && agent.podIds?.includes(task.podId) ? 1 : 0;
+  const preferenceScore = calculatePreferenceScore(agent, task);
+  const reputationMultiplier = clamp(0.75 + agent.reputationScore / 100, 0.75, 1.5);
+
+  return {
+    levelMatch,
+    capabilityOverlap,
+    domainExperience,
+    availabilityScore,
+    podBonus,
+    preferenceScore,
+    reputationMultiplier,
+  };
+}
+
+function calculateCapabilityOverlap(agentCapabilities: string[], requiredCapabilities: string[]): number {
+  if (requiredCapabilities.length === 0) return 1;
+
+  const agentSet = new Set(agentCapabilities.map(normalize));
+  const matches = requiredCapabilities.filter((capability) => agentSet.has(normalize(capability)));
+  return matches.length / requiredCapabilities.length;
+}
+
+function calculatePreferenceScore(agent: MatchAgent, task: MatchTask): number {
+  const domains = new Set((agent.preferredDomains ?? []).map(normalize));
+  const interests = new Set((agent.interests ?? []).map(normalize));
+  const tags = (task.tags ?? []).map(normalize);
+  let score = 0;
+
+  if (domains.has(normalize(task.domain))) score += 0.6;
+  if (tags.some((tag) => interests.has(tag))) score += 0.4;
+
+  return clamp(score, 0, 1);
+}
+
+function buildReasons(
+  agent: MatchAgent,
+  task: MatchTask,
+  breakdown: MatchScoreBreakdown
+): string[] {
+  const reasons: string[] = [];
+
+  if (breakdown.levelMatch === 1) reasons.push('Agent level meets task requirement.');
+  if (breakdown.capabilityOverlap === 1) reasons.push('Agent has all required capabilities.');
+  if (breakdown.capabilityOverlap > 0 && breakdown.capabilityOverlap < 1) {
+    reasons.push('Agent has partial capability overlap.');
+  }
+  if (breakdown.domainExperience > 0) reasons.push('Agent has historical performance in this domain.');
+  if (breakdown.availabilityScore > 0.5) reasons.push('Agent has available workload capacity.');
+  if (breakdown.podBonus === 1) reasons.push('Agent shares the task pod.');
+  if (breakdown.preferenceScore > 0) reasons.push('Task matches agent preferences or interests.');
+  if (agent.activeTaskCount >= agent.maxConcurrentTasks) reasons.push('Agent is currently at workload capacity.');
+  if (LEVEL_RANK[agent.level] < LEVEL_RANK[task.requiredLevel]) reasons.push('Agent level is below task requirement.');
+
+  return reasons;
+}
+
+function getAgent(agentId: string, data: MatchDataSource): MatchAgent {
+  const agent = data.agents.find((item) => item.id === agentId);
+  if (!agent) throw new Error(`Agent not found: ${agentId}`);
+  return agent;
+}
+
+function getTask(taskId: string, data: MatchDataSource): MatchTask {
+  const task = data.tasks.find((item) => item.id === taskId);
+  if (!task) throw new Error(`Task not found: ${taskId}`);
+  return task;
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/bounty/matcher.ts
+++ b/src/bounty/matcher.ts
@@ -21,7 +21,7 @@ export interface MatchTask {
   requiredCapabilities: string[];
   tags?: string[];
   podId?: string;
-  status: 'AVAILABLE' | 'CLAIMED' | 'SUBMITTED' | 'COMPLETED' | 'DISPUTED';
+  status: 'AVAILABLE' | 'CLAIMED' | 'IN_PROGRESS' | 'SUBMITTED' | 'UNDER_REVIEW' | 'COMPLETED' | 'DISPUTED';
 }
 
 export interface MatchDataSource {
@@ -62,21 +62,23 @@ const LEVEL_RANK: Record<AgentLevel, number> = {
 };
 
 export function findMatchingAgents(taskId: string, data: MatchDataSource): MatchResult[] {
-  const task = getTask(taskId, data);
+  const index = createMatchIndex(data);
+  const task = getTask(taskId, index);
   if (task.status !== 'AVAILABLE') return [];
 
   return data.agents
-    .map((agent) => calculateMatchScore(agent.id, task.id, data))
+    .map((agent) => calculateMatchScoreWithIndex(agent.id, task.id, index))
     .filter((result) => result.score > 0)
     .sort((a, b) => b.score - a.score);
 }
 
 export function findMatchingTasks(agentId: string, data: MatchDataSource): MatchResult[] {
-  getAgent(agentId, data);
+  const index = createMatchIndex(data);
+  getAgent(agentId, index);
 
   return data.tasks
     .filter((task) => task.status === 'AVAILABLE')
-    .map((task) => calculateMatchScore(agentId, task.id, data))
+    .map((task) => calculateMatchScoreWithIndex(agentId, task.id, index))
     .filter((result) => result.score > 0)
     .sort((a, b) => b.score - a.score);
 }
@@ -86,8 +88,17 @@ export function calculateMatchScore(
   taskId: string,
   data: MatchDataSource
 ): MatchResult {
-  const agent = getAgent(agentId, data);
-  const task = getTask(taskId, data);
+  return calculateMatchScoreWithIndex(agentId, taskId, createMatchIndex(data));
+}
+
+interface MatchIndex {
+  agentsById: Map<string, MatchAgent>;
+  tasksById: Map<string, MatchTask>;
+}
+
+function calculateMatchScoreWithIndex(agentId: string, taskId: string, index: MatchIndex): MatchResult {
+  const agent = getAgent(agentId, index);
+  const task = getTask(taskId, index);
   const breakdown = buildBreakdown(agent, task);
   const baseScore =
     breakdown.levelMatch * 30 +
@@ -108,8 +119,9 @@ export function calculateMatchScore(
 }
 
 export function autoAssignTask(taskId: string, data: MatchDataSource): MatchResult | null {
+  const index = createMatchIndex(data);
   const eligible = findMatchingAgents(taskId, data).filter((result) => {
-    const agent = getAgent(result.agentId, data);
+    const agent = getAgent(result.agentId, index);
     return agent.optInAutoAssign === true && result.breakdown.availabilityScore > 0;
   });
 
@@ -123,21 +135,25 @@ export function suggestSkillDevelopment(
 ): SkillDevelopmentSuggestion[] {
   const agent = getAgent(agentId, data);
   const ownedCapabilities = new Set(agent.capabilities.map(normalize));
-  const counts = new Map<string, number>();
+  const counts = new Map<string, { capability: string; count: number }>();
 
   for (const task of data.tasks.filter((item) => item.status === 'AVAILABLE')) {
     for (const capability of task.requiredCapabilities) {
       const normalized = normalize(capability);
       if (!ownedCapabilities.has(normalized)) {
-        counts.set(capability, (counts.get(capability) ?? 0) + 1);
+        const current = counts.get(normalized);
+        counts.set(normalized, {
+          capability: current?.capability ?? normalized,
+          count: (current?.count ?? 0) + 1,
+        });
       }
     }
   }
 
-  return Array.from(counts.entries())
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+  return Array.from(counts.values())
+    .sort((a, b) => b.count - a.count || a.capability.localeCompare(b.capability))
     .slice(0, limit)
-    .map(([capability, matchingTaskCount]) => ({
+    .map(({ capability, count: matchingTaskCount }) => ({
       capability,
       matchingTaskCount,
       reason: `${matchingTaskCount} available task(s) require ${capability}.`,
@@ -209,14 +225,21 @@ function buildReasons(
   return reasons;
 }
 
-function getAgent(agentId: string, data: MatchDataSource): MatchAgent {
-  const agent = data.agents.find((item) => item.id === agentId);
+function createMatchIndex(data: MatchDataSource): MatchIndex {
+  return {
+    agentsById: new Map(data.agents.map((agent) => [agent.id, agent])),
+    tasksById: new Map(data.tasks.map((task) => [task.id, task])),
+  };
+}
+
+function getAgent(agentId: string, source: MatchDataSource | MatchIndex): MatchAgent {
+  const agent = 'agentsById' in source ? source.agentsById.get(agentId) : source.agents.find((item) => item.id === agentId);
   if (!agent) throw new Error(`Agent not found: ${agentId}`);
   return agent;
 }
 
-function getTask(taskId: string, data: MatchDataSource): MatchTask {
-  const task = data.tasks.find((item) => item.id === taskId);
+function getTask(taskId: string, source: MatchDataSource | MatchIndex): MatchTask {
+  const task = 'tasksById' in source ? source.tasksById.get(taskId) : source.tasks.find((item) => item.id === taskId);
   if (!task) throw new Error(`Task not found: ${taskId}`);
   return task;
 }

--- a/tests/bounty/matcher.test.ts
+++ b/tests/bounty/matcher.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autoAssignTask,
+  calculateMatchScore,
+  findMatchingAgents,
+  findMatchingTasks,
+  suggestSkillDevelopment,
+  type MatchDataSource,
+} from '../../src/bounty/matcher.js';
+
+const data: MatchDataSource = {
+  agents: [
+    {
+      id: 'agent-strong',
+      level: 'L3_SOVEREIGN',
+      capabilities: ['typescript', 'testing', 'graphql'],
+      interests: ['matching', 'workflow'],
+      preferredDomains: ['bounty'],
+      activeTaskCount: 1,
+      maxConcurrentTasks: 4,
+      reputationScore: 80,
+      completedTasksByDomain: { bounty: 8 },
+      podIds: ['pod-1'],
+      optInAutoAssign: true,
+    },
+    {
+      id: 'agent-busy',
+      level: 'L4_MANAGER',
+      capabilities: ['typescript', 'testing', 'graphql'],
+      preferredDomains: ['bounty'],
+      activeTaskCount: 3,
+      maxConcurrentTasks: 3,
+      reputationScore: 90,
+      completedTasksByDomain: { bounty: 10 },
+      podIds: ['pod-1'],
+      optInAutoAssign: true,
+    },
+    {
+      id: 'agent-junior',
+      level: 'L0_CANDIDATE',
+      capabilities: ['docs'],
+      activeTaskCount: 0,
+      maxConcurrentTasks: 2,
+      reputationScore: 20,
+      completedTasksByDomain: {},
+      optInAutoAssign: false,
+    },
+  ],
+  tasks: [
+    {
+      id: 'task-matcher',
+      domain: 'bounty',
+      requiredLevel: 'L1_WORKER',
+      requiredCapabilities: ['typescript', 'testing'],
+      tags: ['matching'],
+      podId: 'pod-1',
+      status: 'AVAILABLE',
+    },
+    {
+      id: 'task-docs',
+      domain: 'publishing',
+      requiredLevel: 'L0_CANDIDATE',
+      requiredCapabilities: ['docs'],
+      tags: ['workflow'],
+      status: 'AVAILABLE',
+    },
+    {
+      id: 'task-claimed',
+      domain: 'bounty',
+      requiredLevel: 'L1_WORKER',
+      requiredCapabilities: ['typescript'],
+      status: 'CLAIMED',
+    },
+  ],
+};
+
+describe('bounty matcher', () => {
+  it('calculates a weighted match score with a useful breakdown', () => {
+    const result = calculateMatchScore('agent-strong', 'task-matcher', data);
+
+    expect(result.score).toBeGreaterThan(100);
+    expect(result.breakdown.levelMatch).toBe(1);
+    expect(result.breakdown.capabilityOverlap).toBe(1);
+    expect(result.breakdown.podBonus).toBe(1);
+    expect(result.reasons).toContain('Agent has all required capabilities.');
+  });
+
+  it('ranks matching agents for an available task', () => {
+    const matches = findMatchingAgents('task-matcher', data);
+
+    expect(matches[0].agentId).toBe('agent-strong');
+    expect(matches.map((match) => match.agentId)).toContain('agent-busy');
+    expect(matches[0].score).toBeGreaterThan(matches[1].score);
+  });
+
+  it('recommends matching tasks for an agent and excludes claimed tasks', () => {
+    const matches = findMatchingTasks('agent-strong', data);
+
+    expect(matches.map((match) => match.taskId)).toContain('task-matcher');
+    expect(matches.map((match) => match.taskId)).not.toContain('task-claimed');
+  });
+
+  it('auto-assigns only opted-in agents with available capacity', () => {
+    const assignment = autoAssignTask('task-matcher', data);
+
+    expect(assignment?.agentId).toBe('agent-strong');
+    expect(assignment?.breakdown.availabilityScore).toBeGreaterThan(0);
+  });
+
+  it('suggests missing skills based on available task demand', () => {
+    const suggestions = suggestSkillDevelopment('agent-junior', data);
+
+    expect(suggestions[0].capability).toBe('testing');
+    expect(suggestions.map((suggestion) => suggestion.capability)).toContain('typescript');
+  });
+});

--- a/tests/bounty/matcher.test.ts
+++ b/tests/bounty/matcher.test.ts
@@ -71,6 +71,13 @@ const data: MatchDataSource = {
       requiredCapabilities: ['typescript'],
       status: 'CLAIMED',
     },
+    {
+      id: 'task-review',
+      domain: 'bounty',
+      requiredLevel: 'L1_WORKER',
+      requiredCapabilities: ['typescript'],
+      status: 'UNDER_REVIEW',
+    },
   ],
 };
 
@@ -108,9 +115,22 @@ describe('bounty matcher', () => {
   });
 
   it('suggests missing skills based on available task demand', () => {
-    const suggestions = suggestSkillDevelopment('agent-junior', data);
+    const suggestions = suggestSkillDevelopment('agent-junior', {
+      ...data,
+      tasks: [
+        ...data.tasks,
+        {
+          id: 'task-testing-uppercase',
+          domain: 'bounty',
+          requiredLevel: 'L1_WORKER',
+          requiredCapabilities: ['Testing'],
+          status: 'AVAILABLE',
+        },
+      ],
+    });
 
     expect(suggestions[0].capability).toBe('testing');
+    expect(suggestions[0].matchingTaskCount).toBe(2);
     expect(suggestions.map((suggestion) => suggestion.capability)).toContain('typescript');
   });
 });


### PR DESCRIPTION
## Summary
- add `src/bounty/matcher.ts` with ranked agent/task matching, weighted compatibility scoring, opt-in auto-assignment, and skill development suggestions
- add focused Vitest coverage for score breakdowns, ranking, claimed-task exclusion, auto-assignment, and skill recommendations

Closes #6.

## Verification
- `npx vitest run tests/bounty/matcher.test.ts` -> 5 passed

Note: repo-wide `npm run build` is currently blocked by existing project configuration/dependency/type issues unrelated to this module, documented in PR #17.

Payout details: I can provide a Lightning invoice/address if this is accepted for the 1,200 sats bounty.