### PR TITLE
feat: add nostr wallet integration

### DIFF
--- a/src/wallet/nostr.ts
+++ b/src/wallet/nostr.ts
@@ -27,6 +27,7 @@ export interface SubCloser {
 export interface RelayPublisher {
   publish(relays: string[], event: Event): Promise<string>[];
   subscribe(relays: string[], filter: Filter, params: { onevent: (event: Event) => void }): SubCloser;
+  destroy?(): void;
 }
 
 export interface PublishResult {
@@ -83,10 +84,16 @@ export async function publishEvent(event: Event, options: NostrOptions = {}): Pr
   }
 
   const relays = resolveRelays(options.relays);
-  const publisher = options.publisher ?? new SimplePool();
-  const acknowledgements = await Promise.all(publisher.publish(relays, event));
+  const { publisher, ownsPublisher } = resolvePublisher(options.publisher);
 
-  return { event, relays, acknowledgements };
+  try {
+    const acknowledgements = await Promise.all(publisher.publish(relays, event));
+    return { event, relays, acknowledgements };
+  } finally {
+    if (ownsPublisher) {
+      publisher.destroy?.();
+    }
+  }
 }
 
 export async function sendZap(
@@ -124,9 +131,9 @@ export function subscribeToZaps(
 ): SubCloser {
   assertHexPubkey(pubkey);
   const relays = resolveRelays(options.relays);
-  const publisher = options.publisher ?? new SimplePool();
+  const { publisher, ownsPublisher } = resolvePublisher(options.publisher);
 
-  return publisher.subscribe(
+  const subscription = publisher.subscribe(
     relays,
     {
       kinds: [KIND_ZAP_RECEIPT],
@@ -134,6 +141,15 @@ export function subscribeToZaps(
     },
     { onevent: onZap }
   );
+
+  return {
+    close(reason?: string): void {
+      subscription.close(reason);
+      if (ownsPublisher) {
+        publisher.destroy?.();
+      }
+    },
+  };
 }
 
 export function createAttestation(data: object, options: NostrOptions = {}): VerifiedEvent {
@@ -141,12 +157,13 @@ export function createAttestation(data: object, options: NostrOptions = {}): Ver
   const privateKey = options.privateKey ?? loadPrivateKey();
   const publicKey = getPublicKey(normalizePrivateKey(privateKey));
   const digest = stableHash(attestation.data);
+  const content = canonicalize(attestation.data);
 
   return signEvent(
     {
       kind: KIND_APP_DATA,
       created_at: now(),
-      content: JSON.stringify(attestation.data),
+      content,
       tags: [
         ['d', `ds-attestation:${digest}`],
         ['t', 'attestation'],
@@ -255,6 +272,14 @@ function resolveRelays(relays?: string[]): string[] {
   return relays?.length ? parseRelayList(relays.join(',')) : parseRelayList();
 }
 
+function resolvePublisher(publisher?: RelayPublisher): { publisher: RelayPublisher; ownsPublisher: boolean } {
+  if (publisher) {
+    return { publisher, ownsPublisher: false };
+  }
+
+  return { publisher: new SimplePool(), ownsPublisher: true };
+}
+
 function loadPrivateKey(): Uint8Array {
   const value = process.env.NOSTR_PRIVATE_KEY;
   if (!value) {
@@ -308,6 +333,9 @@ function stableHash(value: object): string {
 }
 
 function canonicalize(value: unknown): string {
+  if (value === undefined) {
+    return 'null';
+  }
   if (Array.isArray(value)) {
     return `[${value.map(canonicalize).join(',')}]`;
   }

--- a/src/wallet/nostr.ts
+++ b/src/wallet/nostr.ts
@@ -1,0 +1,322 @@
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  nip19,
+  nip57,
+  SimplePool,
+  verifyEvent,
+  type Event,
+  type EventTemplate,
+  type Filter,
+  type VerifiedEvent,
+} from 'nostr-tools';
+import { createHash } from 'node:crypto';
+
+export interface NostrKeypair {
+  privateKey: string;
+  publicKey: string;
+  nsec: string;
+  npub: string;
+}
+
+export interface SubCloser {
+  close(reason?: string): void;
+}
+
+export interface RelayPublisher {
+  publish(relays: string[], event: Event): Promise<string>[];
+  subscribe(relays: string[], filter: Filter, params: { onevent: (event: Event) => void }): SubCloser;
+}
+
+export interface PublishResult {
+  event: VerifiedEvent;
+  relays: string[];
+  acknowledgements: string[];
+}
+
+export interface ZapResult extends PublishResult {
+  zapRequest: VerifiedEvent;
+  amountSats: number;
+}
+
+export interface AttestationInput {
+  type?: string;
+  subject?: string;
+  data: object;
+}
+
+export interface NostrOptions {
+  privateKey?: string | Uint8Array;
+  relays?: string[];
+  publisher?: RelayPublisher;
+}
+
+const DEFAULT_RELAY = 'wss://relay.damus.io';
+const KIND_ZAP_REQUEST = 9734;
+const KIND_ZAP_RECEIPT = 9735;
+const KIND_BADGE_DEFINITION = 30009;
+const KIND_BADGE_AWARD = 8;
+const KIND_APP_DATA = 30078;
+
+export type NostrEvent = Event;
+
+export function generateKeypair(): NostrKeypair {
+  const secretKey = generateSecretKey();
+  const publicKey = getPublicKey(secretKey);
+
+  return {
+    privateKey: bytesToHex(secretKey),
+    publicKey,
+    nsec: nip19.nsecEncode(secretKey),
+    npub: nip19.npubEncode(publicKey),
+  };
+}
+
+export function signEvent(event: EventTemplate, privateKey: string | Uint8Array = loadPrivateKey()): VerifiedEvent {
+  return finalizeEvent(event, normalizePrivateKey(privateKey));
+}
+
+export async function publishEvent(event: Event, options: NostrOptions = {}): Promise<PublishResult> {
+  if (!verifyEvent(event)) {
+    throw new Error('Cannot publish an unsigned or invalid Nostr event.');
+  }
+
+  const relays = resolveRelays(options.relays);
+  const publisher = options.publisher ?? new SimplePool();
+  const acknowledgements = await Promise.all(publisher.publish(relays, event));
+
+  return { event, relays, acknowledgements };
+}
+
+export async function sendZap(
+  recipientPubkey: string,
+  amount: number,
+  message = '',
+  options: NostrOptions = {}
+): Promise<ZapResult> {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error('Zap amount must be a positive integer number of sats.');
+  }
+  assertHexPubkey(recipientPubkey);
+
+  const relays = resolveRelays(options.relays);
+  const unsignedZap = nip57.makeZapRequest({
+    pubkey: recipientPubkey,
+    amount: amount * 1000,
+    comment: message,
+    relays,
+  });
+  const zapRequest = signEvent(unsignedZap, options.privateKey ?? loadPrivateKey());
+  const result = await publishEvent(zapRequest, { ...options, relays });
+
+  return {
+    ...result,
+    zapRequest,
+    amountSats: amount,
+  };
+}
+
+export function subscribeToZaps(
+  pubkey: string,
+  onZap: (event: Event) => void,
+  options: NostrOptions = {}
+): SubCloser {
+  assertHexPubkey(pubkey);
+  const relays = resolveRelays(options.relays);
+  const publisher = options.publisher ?? new SimplePool();
+
+  return publisher.subscribe(
+    relays,
+    {
+      kinds: [KIND_ZAP_RECEIPT],
+      '#p': [pubkey],
+    },
+    { onevent: onZap }
+  );
+}
+
+export function createAttestation(data: object, options: NostrOptions = {}): VerifiedEvent {
+  const attestation = normalizeAttestation(data);
+  const privateKey = options.privateKey ?? loadPrivateKey();
+  const publicKey = getPublicKey(normalizePrivateKey(privateKey));
+  const digest = stableHash(attestation.data);
+
+  return signEvent(
+    {
+      kind: KIND_APP_DATA,
+      created_at: now(),
+      content: JSON.stringify(attestation.data),
+      tags: [
+        ['d', `ds-attestation:${digest}`],
+        ['t', 'attestation'],
+        ['type', attestation.type],
+        ['subject', attestation.subject],
+        ['hash', digest],
+        ['p', publicKey],
+      ],
+    },
+    privateKey
+  );
+}
+
+export function createAgentCredentialBadge(
+  credentialId: string,
+  name: string,
+  description: string,
+  options: NostrOptions = {}
+): VerifiedEvent {
+  const d = credentialId.trim();
+  if (!d || !name.trim()) {
+    throw new Error('Badge credential id and name are required.');
+  }
+
+  return signEvent(
+    {
+      kind: KIND_BADGE_DEFINITION,
+      created_at: now(),
+      content: description,
+      tags: [
+        ['d', d],
+        ['name', name],
+        ['description', description],
+      ],
+    },
+    options.privateKey ?? loadPrivateKey()
+  );
+}
+
+export function awardAgentCredentialBadge(
+  badgeAddress: string,
+  recipientPubkey: string,
+  options: NostrOptions = {}
+): VerifiedEvent {
+  assertHexPubkey(recipientPubkey);
+
+  return signEvent(
+    {
+      kind: KIND_BADGE_AWARD,
+      created_at: now(),
+      content: '',
+      tags: [
+        ['a', badgeAddress],
+        ['p', recipientPubkey],
+      ],
+    },
+    options.privateKey ?? loadPrivateKey()
+  );
+}
+
+export function parseRelayList(value = process.env.NOSTR_RELAY_LIST ?? process.env.NOSTR_RELAY_URL): string[] {
+  if (!value?.trim()) {
+    return [DEFAULT_RELAY];
+  }
+
+  const relays = value
+    .split(',')
+    .map((relay) => relay.trim())
+    .filter(Boolean);
+
+  if (relays.length === 0) {
+    return [DEFAULT_RELAY];
+  }
+
+  for (const relay of relays) {
+    if (!relay.startsWith('wss://') && !relay.startsWith('ws://')) {
+      throw new Error(`Invalid Nostr relay URL: ${relay}`);
+    }
+  }
+
+  return [...new Set(relays)];
+}
+
+export function isSignedEvent(event: Event): boolean {
+  return verifyEvent(event);
+}
+
+function normalizeAttestation(data: object): Required<AttestationInput> {
+  if ('data' in data && typeof (data as AttestationInput).data === 'object') {
+    const input = data as AttestationInput;
+    return {
+      type: input.type ?? 'record',
+      subject: input.subject ?? 'agent',
+      data: input.data,
+    };
+  }
+
+  return {
+    type: 'record',
+    subject: 'agent',
+    data,
+  };
+}
+
+function resolveRelays(relays?: string[]): string[] {
+  return relays?.length ? parseRelayList(relays.join(',')) : parseRelayList();
+}
+
+function loadPrivateKey(): Uint8Array {
+  const value = process.env.NOSTR_PRIVATE_KEY;
+  if (!value) {
+    throw new Error('NOSTR_PRIVATE_KEY is required for signing.');
+  }
+
+  return normalizePrivateKey(value);
+}
+
+function normalizePrivateKey(privateKey: string | Uint8Array): Uint8Array {
+  if (privateKey instanceof Uint8Array) {
+    if (privateKey.length !== 32) {
+      throw new Error('Nostr private key must be 32 bytes.');
+    }
+
+    return privateKey;
+  }
+
+  if (privateKey.startsWith('nsec1')) {
+    const decoded = nip19.decode(privateKey);
+    if (decoded.type !== 'nsec') {
+      throw new Error('Expected an nsec private key.');
+    }
+
+    return decoded.data;
+  }
+
+  if (!/^[a-f0-9]{64}$/i.test(privateKey)) {
+    throw new Error('Nostr private key must be 64 hex characters or nsec encoded.');
+  }
+
+  return Uint8Array.from(Buffer.from(privateKey, 'hex'));
+}
+
+function assertHexPubkey(pubkey: string): void {
+  if (!/^[a-f0-9]{64}$/i.test(pubkey)) {
+    throw new Error('Nostr public key must be 64 hex characters.');
+  }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function now(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function stableHash(value: object): string {
+  return createHash('sha256').update(canonicalize(value)).digest('hex');
+}
+
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalize(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}

--- a/tests/wallet/nostr.test.ts
+++ b/tests/wallet/nostr.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  awardAgentCredentialBadge,
+  createAgentCredentialBadge,
+  createAttestation,
+  generateKeypair,
+  isSignedEvent,
+  parseRelayList,
+  publishEvent,
+  sendZap,
+  signEvent,
+  subscribeToZaps,
+  type RelayPublisher,
+} from '../../src/wallet/nostr.js';
+import type { Event, Filter } from 'nostr-tools';
+import type { SubCloser } from '../../src/wallet/nostr.js';
+
+class FakePublisher implements RelayPublisher {
+  public published: Array<{ relays: string[]; event: Event }> = [];
+  public subscriptions: Array<{ relays: string[]; filter: Filter }> = [];
+
+  publish(relays: string[], event: Event): Promise<string>[] {
+    this.published.push({ relays, event });
+    return relays.map((relay) => Promise.resolve(`${relay}:ok`));
+  }
+
+  subscribe(relays: string[], filter: Filter, params: { onevent: (event: Event) => void }): SubCloser {
+    this.subscriptions.push({ relays, filter });
+    return {
+      close: () => undefined,
+    };
+  }
+}
+
+describe('nostr wallet integration', () => {
+  it('generates Nostr keypairs and signs verifiable NIP-01 events', () => {
+    const keypair = generateKeypair();
+    const event = signEvent(
+      {
+        kind: 1,
+        content: 'hello sovereign agents',
+        tags: [],
+        created_at: 1_772_000_000,
+      },
+      keypair.privateKey
+    );
+
+    expect(keypair.privateKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(keypair.publicKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(keypair.nsec).toMatch(/^nsec1/);
+    expect(keypair.npub).toMatch(/^npub1/);
+    expect(event.pubkey).toBe(keypair.publicKey);
+    expect(isSignedEvent(event)).toBe(true);
+  });
+
+  it('publishes signed events to configured relays', async () => {
+    const keypair = generateKeypair();
+    const publisher = new FakePublisher();
+    const event = createAttestation({ action: 'claim-task', taskId: 'task-1' }, { privateKey: keypair.privateKey });
+    const result = await publishEvent(event, {
+      relays: ['wss://relay.one', 'wss://relay.two'],
+      publisher,
+    });
+
+    expect(result.acknowledgements).toEqual(['wss://relay.one:ok', 'wss://relay.two:ok']);
+    expect(publisher.published).toHaveLength(1);
+    expect(publisher.published[0].event.id).toBe(event.id);
+  });
+
+  it('creates and publishes NIP-57 zap requests without hitting live relays in tests', async () => {
+    const sender = generateKeypair();
+    const recipient = generateKeypair();
+    const publisher = new FakePublisher();
+    const result = await sendZap(recipient.publicKey, 21, 'paid for useful work', {
+      privateKey: sender.privateKey,
+      relays: ['wss://relay.example'],
+      publisher,
+    });
+
+    expect(result.amountSats).toBe(21);
+    expect(result.zapRequest.kind).toBe(9734);
+    expect(result.zapRequest.pubkey).toBe(sender.publicKey);
+    expect(result.zapRequest.tags).toContainEqual(['p', recipient.publicKey]);
+    expect(result.zapRequest.tags).toContainEqual(['amount', '21000']);
+    expect(publisher.published[0].event.id).toBe(result.zapRequest.id);
+  });
+
+  it('subscribes to incoming zap receipts for a pubkey', () => {
+    const recipient = generateKeypair();
+    const publisher = new FakePublisher();
+    const sub = subscribeToZaps(recipient.publicKey, () => undefined, {
+      relays: ['wss://relay.example'],
+      publisher,
+    });
+
+    expect(publisher.subscriptions).toHaveLength(1);
+    expect(publisher.subscriptions[0].filter).toMatchObject({
+      kinds: [9735],
+      '#p': [recipient.publicKey],
+    });
+    expect(() => sub.close()).not.toThrow();
+  });
+
+  it('creates immutable attestations and NIP-58 badge events', () => {
+    const issuer = generateKeypair();
+    const recipient = generateKeypair();
+    const attestation = createAttestation(
+      { type: 'task-proof', subject: 'task-42', data: { completed: true, score: 98 } },
+      { privateKey: issuer.privateKey }
+    );
+    const badge = createAgentCredentialBadge('agent-reviewer', 'Agent Reviewer', 'Can review agent work', {
+      privateKey: issuer.privateKey,
+    });
+    const award = awardAgentCredentialBadge(
+      `30009:${issuer.publicKey}:agent-reviewer`,
+      recipient.publicKey,
+      { privateKey: issuer.privateKey }
+    );
+
+    expect(attestation.kind).toBe(30078);
+    expect(attestation.tags.some((tag) => tag[0] === 'hash')).toBe(true);
+    expect(badge.kind).toBe(30009);
+    expect(award.kind).toBe(8);
+    expect(award.tags).toContainEqual(['p', recipient.publicKey]);
+  });
+
+  it('parses relay environment values defensively', () => {
+    expect(parseRelayList('wss://relay.one,wss://relay.one,wss://relay.two')).toEqual([
+      'wss://relay.one',
+      'wss://relay.two',
+    ]);
+    expect(() => parseRelayList('https://not-a-relay')).toThrow('Invalid Nostr relay URL');
+  });
+});

--- a/tests/wallet/nostr.test.ts
+++ b/tests/wallet/nostr.test.ts
@@ -18,6 +18,7 @@ import type { SubCloser } from '../../src/wallet/nostr.js';
 class FakePublisher implements RelayPublisher {
   public published: Array<{ relays: string[]; event: Event }> = [];
   public subscriptions: Array<{ relays: string[]; filter: Filter }> = [];
+  public destroyCount = 0;
 
   publish(relays: string[], event: Event): Promise<string>[] {
     this.published.push({ relays, event });
@@ -29,6 +30,10 @@ class FakePublisher implements RelayPublisher {
     return {
       close: () => undefined,
     };
+  }
+
+  destroy(): void {
+    this.destroyCount += 1;
   }
 }
 
@@ -119,9 +124,34 @@ describe('nostr wallet integration', () => {
 
     expect(attestation.kind).toBe(30078);
     expect(attestation.tags.some((tag) => tag[0] === 'hash')).toBe(true);
+    expect(attestation.content).toBe('{"completed":true,"score":98}');
     expect(badge.kind).toBe(30009);
     expect(award.kind).toBe(8);
     expect(award.tags).toContainEqual(['p', recipient.publicKey]);
+  });
+
+  it('canonicalizes undefined attestation values without runtime errors', () => {
+    const issuer = generateKeypair();
+    const attestation = createAttestation(
+      { type: 'task-proof', subject: 'task-43', data: { completed: true, optional: undefined } },
+      { privateKey: issuer.privateKey }
+    );
+
+    expect(attestation.content).toBe('{"completed":true,"optional":null}');
+    expect(isSignedEvent(attestation)).toBe(true);
+  });
+
+  it('closes internally owned subscriptions without affecting injected publishers', () => {
+    const recipient = generateKeypair();
+    const publisher = new FakePublisher();
+    const sub = subscribeToZaps(recipient.publicKey, () => undefined, {
+      relays: ['wss://relay.example'],
+      publisher,
+    });
+
+    sub.close();
+
+    expect(publisher.destroyCount).toBe(0);
   });
 
   it('parses relay environment values defensively', () => {


### PR DESCRIPTION
## Summary
- adds `src/wallet/nostr.ts` with Nostr keypair generation, event signing/verification, relay publishing, zap request publishing, zap receipt subscriptions, immutable attestations, and NIP-58 badge helpers
- supports `NOSTR_RELAY_URL`, `NOSTR_RELAY_LIST`, and `NOSTR_PRIVATE_KEY` while still allowing injected relays/private keys for tests and services
- adds offline Vitest coverage for NIP-01 signing, relay publishing, NIP-57 zap requests, zap subscriptions, attestations, badge events, and relay parsing

## Verification
- `npx vitest run tests/wallet/nostr.test.ts` (6 passed)
- `npx tsc --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext src/wallet/nostr.ts tests/wallet/nostr.test.ts`

Note: tests use an injected relay publisher so they do not hit live relays or attempt Lightning settlement. The repo-wide `npm run build` remains blocked by pre-existing unrelated project issues noted on the other DS bounty PRs (`database/**/*` outside `rootDir`, missing `@as-integrations/fastify`, and existing Drizzle/resolver typing errors).

Closes #2