### PR TITLE
test: cover bounty board resolver

### DIFF
--- a/tests/graphql/bounty-board.test.ts
+++ b/tests/graphql/bounty-board.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createResolvers } from '../../src/graphql/resolvers.js';
 
+type ResolverDb = Parameters<typeof createResolvers>[0];
+
 function mockSelectChain(result: unknown[], terminal: 'where' | 'orderBy' = 'where') {
   const orderBy = vi.fn().mockResolvedValue(result);
   const where = terminal === 'where' ? vi.fn().mockResolvedValue(result) : vi.fn(() => ({ orderBy }));
@@ -31,7 +33,7 @@ describe('bountyBoard resolver', () => {
         .mockReturnValueOnce(totalBountyQuery.chain),
     };
 
-    const resolvers = createResolvers(db as never);
+    const resolvers = createResolvers(db as unknown as ResolverDb);
     const board = await resolvers.Query.bountyBoard();
 
     expect(board.availableTasks()).toEqual(availableTasks);
@@ -40,6 +42,8 @@ describe('bountyBoard resolver', () => {
     expect(board.domainStats).toEqual([]);
     expect(db.select).toHaveBeenCalledTimes(3);
     expect(availableQuery.orderBy).toHaveBeenCalledTimes(1);
+    expect(taskCountQuery.where).toHaveBeenCalledTimes(1);
+    expect(totalBountyQuery.where).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to zero aggregate values when no rows are returned', async () => {
@@ -54,7 +58,7 @@ describe('bountyBoard resolver', () => {
         .mockReturnValueOnce(totalBountyQuery.chain),
     };
 
-    const resolvers = createResolvers(db as never);
+    const resolvers = createResolvers(db as unknown as ResolverDb);
     const board = await resolvers.Query.bountyBoard();
 
     expect(board.availableTasks()).toEqual([]);

--- a/tests/graphql/bounty-board.test.ts
+++ b/tests/graphql/bounty-board.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createResolvers } from '../../src/graphql/resolvers.js';
+
+function mockSelectChain(result: unknown[], terminal: 'where' | 'orderBy' = 'where') {
+  const orderBy = vi.fn().mockResolvedValue(result);
+  const where = terminal === 'where' ? vi.fn().mockResolvedValue(result) : vi.fn(() => ({ orderBy }));
+  const from = vi.fn(() => ({ where }));
+
+  return {
+    chain: { from },
+    from,
+    where,
+    orderBy,
+  };
+}
+
+describe('bountyBoard resolver', () => {
+  it('returns available tasks and aggregate bounty stats', async () => {
+    const availableTasks = [
+      { id: 'task-1', status: 'AVAILABLE', bountyAmount: '2500' },
+      { id: 'task-2', status: 'AVAILABLE', bountyAmount: '1000' },
+    ];
+    const availableQuery = mockSelectChain(availableTasks, 'orderBy');
+    const taskCountQuery = mockSelectChain([{ count: 2 }]);
+    const totalBountyQuery = mockSelectChain([{ total: '3500' }]);
+    const db = {
+      select: vi
+        .fn()
+        .mockReturnValueOnce(availableQuery.chain)
+        .mockReturnValueOnce(taskCountQuery.chain)
+        .mockReturnValueOnce(totalBountyQuery.chain),
+    };
+
+    const resolvers = createResolvers(db as never);
+    const board = await resolvers.Query.bountyBoard();
+
+    expect(board.availableTasks()).toEqual(availableTasks);
+    expect(board.taskCount).toBe(2);
+    expect(board.totalBountyPool).toBe('3500');
+    expect(board.domainStats).toEqual([]);
+    expect(db.select).toHaveBeenCalledTimes(3);
+    expect(availableQuery.orderBy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to zero aggregate values when no rows are returned', async () => {
+    const availableQuery = mockSelectChain([], 'orderBy');
+    const taskCountQuery = mockSelectChain([]);
+    const totalBountyQuery = mockSelectChain([]);
+    const db = {
+      select: vi
+        .fn()
+        .mockReturnValueOnce(availableQuery.chain)
+        .mockReturnValueOnce(taskCountQuery.chain)
+        .mockReturnValueOnce(totalBountyQuery.chain),
+    };
+
+    const resolvers = createResolvers(db as never);
+    const board = await resolvers.Query.bountyBoard();
+
+    expect(board.availableTasks()).toEqual([]);
+    expect(board.taskCount).toBe(0);
+    expect(board.totalBountyPool).toBe('0');
+  });
+});


### PR DESCRIPTION
Contributes to #8.

Summary:
- add a focused Vitest coverage slice for the `bountyBoard` GraphQL resolver
- mock the Drizzle select chains so the resolver behavior is exercised without a live database
- cover both populated aggregate results and zero-value fallbacks

Validation:
- `npm test -- --run tests/graphql/bounty-board.test.ts`
- `npm test -- --run`
- `git diff --check`

Note: `npm run build` currently fails on the base branch for unrelated TypeScript/dependency issues (`database/schema/agents.ts` self-reference typing, `rootDir` including `database/**/*`, and missing `@as-integrations/fastify`). This PR only adds resolver tests and keeps its validation to the passing Vitest path.

Bounty/payout note: issue #8 lists ongoing 50 sats per test file merged. I can provide a Lightning invoice on acceptance; EVM fallback if useful: 0xB34D185318b34ec2F9E060F662Cc7feA3180049c